### PR TITLE
Fix register

### DIFF
--- a/app_api/views/auth.py
+++ b/app_api/views/auth.py
@@ -52,6 +52,8 @@ def register_user(request):
     
     token = Token.objects.create(user=new_user)
     # TODO: If you need to send the client more information update the data dict
+
+    # GM I added the 'valid: True' data to the dict - client side needs it to complete register workflow.
     
     data = { 'token': token.key, 'user_id': new_user.id, 'valid': True}
     return Response(data, status=status.HTTP_201_CREATED)

--- a/app_api/views/auth.py
+++ b/app_api/views/auth.py
@@ -53,5 +53,5 @@ def register_user(request):
     token = Token.objects.create(user=new_user)
     # TODO: If you need to send the client more information update the data dict
     
-    data = { 'token': token.key, 'user_id': new_user.id }
+    data = { 'token': token.key, 'user_id': new_user.id, 'valid': True}
     return Response(data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
# Description

Fixed issue w/ register. After registering, the page would not redirect to the homepage with new user logged in. Issue was with the response from register_user on server side - client side logic was looking for a "valid: true" key-value pair in the response from the server side, which was not there. Added this into the register_user method, everything should work now.

Fixes # 45

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Try to register a new user. After you click register, you should be redirected to the home page and be logged in as new user.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings