### PR TITLE
server tells client side whether current user is an admin

### DIFF
--- a/app_api/views/auth.py
+++ b/app_api/views/auth.py
@@ -26,7 +26,8 @@ def login_user(request):
         data = {
             'valid': True,
             'token': token.key,
-            'user_id': authenticated_user.id
+            'user_id': authenticated_user.id,
+            'is_staff': authenticated_user.is_staff 
         }
     else:
         data = { 'valid': False }
@@ -55,5 +56,5 @@ def register_user(request):
 
     # GM I added the 'valid: True' data to the dict - client side needs it to complete register workflow.
     
-    data = { 'token': token.key, 'user_id': new_user.id, 'valid': True}
+    data = { 'token': token.key, 'user_id': new_user.id, 'valid': True, 'is_staff': new_user.is_staff}
     return Response(data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
# Description

when a user logs in or registers (invokes login_user or register_user) the user's is_staff property is sent back to the client side in the json response along with userId and authentication token

Fixes part of issue #22

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. After pulling this, go into client side
2. Log out and log back into client side
3. Find the "login" fetch call under the network tab. See if "is_staff" is a property of the json response.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
